### PR TITLE
don't implement `AbstractTrees.children` for the symbol graph directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Given a context-free grammar, parse input data to get a parse tree. Supports unparsing, with perfect roundtripping, depending on the implementation for the specific format.
 
-The parse tree type implements the [AbstractTrees](https://github.com/JuliaCollections/AbstractTrees.jl) interface.
+Implements the [AbstractTrees](https://github.com/JuliaCollections/AbstractTrees.jl) interface.
 
 Some dependent packages:
 
@@ -84,16 +84,17 @@ false
 julia> using AbstractTrees: print_tree  # let's see the parse tree!
 
 julia> function print_tree_map(io::IO, tree)
-           kind = root_symbol_kind(tree)
-           if root_is_terminal(tree)
-               show(io, (kind, root_token(tree)))  # a terminal symbol may have extra info (although it's just `nothing` in this example)
+           g = tree.graph
+           kind = root_symbol_kind(g)
+           if root_is_terminal(g)
+               show(io, (kind, root_token(g)))  # a terminal symbol may have extra info (although it's just `nothing` in this example)
            else
                show(io, kind)  # a nonterminal symbol just has its symbol kind
            end
        end
 print_tree_map (generic function with 1 method)
 
-julia> print_tree(print_tree_map, stdout, parser("(()())")[1]; maxdepth = 100)
+julia> print_tree(print_tree_map, stdout, graph_as_tree(parser("(()())")[1]); maxdepth = 100)
 'S'
 ├─ ('(', nothing)
 ├─ 'S'

--- a/src/ParseUnparse.jl
+++ b/src/ParseUnparse.jl
@@ -441,6 +441,7 @@ module ParseUnparse
     module SymbolGraphs
         export
             parse, unparse,
+            graph_as_tree,
             SymbolGraphNodeIdentity, make_node_vec,
             SymbolGraphRootless,
             SymbolGraphRooted,
@@ -825,8 +826,22 @@ module ParseUnparse
             end
             (ret, error_status)
         end
-        function AbstractTrees.children(tree::SymbolGraphRooted)
-            root_children(tree)
+        struct AsTree{Graph <: SymbolGraphRooted}
+            graph::Graph
+            function AsTree(graph::SymbolGraphRooted)
+                new{typeof(graph)}(graph)
+            end
+        end
+        """
+            graph_as_tree(graph::SymbolGraphRooted)
+
+        Wrap to assume the graph is a tree. The return type implements the AbstractTrees.jl interface.
+        """
+        function graph_as_tree(graph::SymbolGraphRooted)
+            AsTree(graph)
+        end
+        function AbstractTrees.children(tree::AsTree)
+            Iterators.map(graph_as_tree, root_children(tree.graph))
         end
     end
     """

--- a/test/runtests_implement_abstract_trees.jl
+++ b/test/runtests_implement_abstract_trees.jl
@@ -32,19 +32,23 @@ function string_to_toks(s::String)
     Iterators.map(f, s)
 end
 
+function get_root_symbol_kind(tree)
+    root_symbol_kind(tree.graph)
+end
+
 @testset "implement the AbstractTrees interface" begin
     @testset "example_string: $(example.string)" for example ∈ dyck_language_examples
         @test let toks = string_to_toks(example.string)
             (tree, _) = SymbolGraphs.parse(dyck_language_parser, toks)
-            example.leaves == @inferred collect(Char, Iterators.map(root_symbol_kind, AbstractTrees.Leaves(tree)))
+            example.leaves == @inferred collect(Char, Iterators.map(get_root_symbol_kind, AbstractTrees.Leaves(graph_as_tree(tree))))
         end
         @test let toks = string_to_toks(example.string)
             (tree, _) = SymbolGraphs.parse(dyck_language_parser, toks)
-            example.preorder == @inferred collect(Char, Iterators.map(root_symbol_kind, AbstractTrees.PreOrderDFS(tree)))
+            example.preorder == @inferred collect(Char, Iterators.map(get_root_symbol_kind, AbstractTrees.PreOrderDFS(graph_as_tree(tree))))
         end
         @test let toks = string_to_toks(example.string)
             (tree, _) = SymbolGraphs.parse(dyck_language_parser, toks)
-            example.postorder == @inferred collect(Char, Iterators.map(root_symbol_kind, AbstractTrees.PostOrderDFS(tree)))
+            example.postorder == @inferred collect(Char, Iterators.map(get_root_symbol_kind, AbstractTrees.PostOrderDFS(graph_as_tree(tree))))
         end
     end
 end


### PR DESCRIPTION
Seems safer to add a wrapper type for this purpose, given that the type system does not guarantee that the symbol graph is a tree.